### PR TITLE
Fix dumpdata command issue and no require auth.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.swp
 docs/_build
 dist/
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
-language: python
 sudo: false
-python:
-  - 2.7
-  - 3.3
-  - 3.4
+language: python
 install:
-  - pip install Pillow
-  - pip install .
-script:
-  - python runtests.py
+  - travis_retry pip install tox
+script: tox

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "Django>=1.7",
-        "mock",
+        "Django>=1.8",
         "requests",
     ],
     classifiers=[

--- a/synctool/auth.py
+++ b/synctool/auth.py
@@ -26,6 +26,9 @@ def decode(value):
 
 def require_token(token):
     def decorator(func):
+        if not token:
+            return func
+
         def inner(request, *args, **kwargs):
             key = request.META.get("HTTP_AUTHORIZATION")
             username, password = decode_header(key)

--- a/synctool/routing.py
+++ b/synctool/routing.py
@@ -16,7 +16,7 @@ class Route(object):
 
     def __init__(self, *args, **kwargs):
         self.api_token = (
-            kwargs.get("api_token") or settings.SYNCTOOL_API_TOKEN
+            kwargs.get("api_token") or getattr(settings, 'SYNCTOOL_API_TOKEN', None)
         )
         self.urlpatterns = []
 

--- a/synctool/routing.py
+++ b/synctool/routing.py
@@ -18,7 +18,12 @@ class Route(object):
         self.api_token = (
             kwargs.get("api_token") or getattr(settings, 'SYNCTOOL_API_TOKEN', None)
         )
-        self.urlpatterns = []
+        self._urlpatterns = []
+
+    @property
+    def urlpatterns(self):
+        # Django 1.9 requires urlpatterns to be hashable
+        return tuple(self._urlpatterns)
 
     def queryset(self, path):
         def decorator(func):
@@ -51,7 +56,7 @@ class Route(object):
 
     def add_url(self, path, func):
         auth = require_token(token=self.api_token)
-        self.urlpatterns.append(
+        self._urlpatterns.append(
             url(
                 regex="^%s/?$" % path,
                 view=auth(func),

--- a/synctool/routing.py
+++ b/synctool/routing.py
@@ -5,7 +5,7 @@ except ImportError:
 
 from django.conf import settings
 from django.conf.urls import url
-from django.core.management.commands.dumpdata import Command
+from django.core.management import call_command
 from django.core.serializers import serialize
 from django.http import HttpResponse
 
@@ -38,11 +38,10 @@ class Route(object):
 
     def app(self, path, label):
         def view(request):
-            cmd = Command()
-            cmd.stdout = StringIO()
-            cmd.handle(label, format="json", exclude=[])
+            stdout = StringIO()
+            call_command('dumpdata', label, stdout=stdout)
             return HttpResponse(
-                content=cmd.stdout.getvalue(),
+                content=stdout.getvalue(),
                 content_type="application/json",
             )
 

--- a/synctool/tests.py
+++ b/synctool/tests.py
@@ -4,7 +4,7 @@ import shutil
 
 from django.core.files import File
 from django.core.serializers import deserialize
-from django.test import RequestFactory, TestCase, mock, override_settings
+from django.test import RequestFactory, TestCase, override_settings
 
 from mock import patch
 import requests

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+args_are_paths = false
+skip_missing_interpreters = true
+envlist = py{27,33,34,35}-dj18,py{27,34,35}-dj19,flake8
+
+[testenv]
+usedevelop = true
+pip_pre = true
+commands = ./runtests.py
+deps =
+    dj18: Django>=1.8,<1.9
+    dj19: Django>=1.9,<1.10
+    requests==2.0.0
+    mock==1.0.1
+
+[testenv:flake8]
+deps = flake8==2.5.1
+commands = flake8 synctool
+
+[flake8]
+max-line-length=120


### PR DESCRIPTION
Was getting no data. Turns out the default arguments for dumpdata were
required. Using `call_command` fixes this.

Also our data is not private. Would like to avoid the auth token.
